### PR TITLE
Add test results artifact upload to GitHub Actions

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -27,6 +27,13 @@ jobs:
         with:
           test-results: test-results.json
 
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: test-results.json
+
       - name: Check coverage
         uses: vladopajic/go-test-coverage@v2
         with:


### PR DESCRIPTION
## Summary
• Adds artifact upload step for test-results.json in GitHub Actions workflow
• Ensures test results are available even when tests fail, improving debugging capability
• Uses `if: always()` condition to upload results regardless of test outcome

## Test plan
- [ ] Verify workflow runs successfully
- [ ] Check that test-results.json artifact is uploaded
- [ ] Confirm artifact is available on both passing and failing test runs

🤖 Generated with [Claude Code](https://claude.ai/code)