### PR TITLE
fix: Race condition with tests and sqlite init

### DIFF
--- a/config.go
+++ b/config.go
@@ -12,6 +12,7 @@ const configFilename = "hal.yaml"
 type Config struct {
 	HomeAssistant HomeAssistantConfig `yaml:"homeAssistant"`
 	Location      LocationConfig      `yaml:"location"`
+	DatabasePath  string              `yaml:"databasePath"`
 }
 
 type HomeAssistantConfig struct {

--- a/connection.go
+++ b/connection.go
@@ -40,7 +40,12 @@ type ConnectionBinder interface {
 }
 
 func NewConnection(cfg Config) *Connection {
-	db, err := store.Open("sqlite.db")
+	dbPath := cfg.DatabasePath
+	if dbPath == "" {
+		dbPath = "sqlite.db"
+	}
+
+	db, err := store.Open(dbPath)
 	if err != nil {
 		panic(err)
 	}

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -32,6 +32,7 @@ func NewClientServer(t *testing.T) (*hal.Connection, *hassws.Server, func()) {
 			Token:  "test-token",
 			UserID: TestUserID,
 		},
+		DatabasePath: ":memory:",
 	})
 
 	// Create test entity and register it


### PR DESCRIPTION
Should fix the error:

```
panic: SQL logic error: table `entities` already exists (1) [recovered]
	panic: SQL logic error: table `entities` already exists (1)
```

By using in-memory sqlite databases for tests instead of sharing one on
the filesystem.
