### PR TITLE
Address review feedback on out-of-order state fix (#14)

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -285,8 +285,13 @@ func (h *Connection) StateChangeEvent(event hassws.EventMessage) {
 	// Drop stale updates that arrive out of order. Home Assistant events can be
 	// reordered in transit, and a reconnect resync can race with live events; an
 	// older state must never overwrite a newer one. Equal timestamps still apply.
+	//
+	// Only compare when the incoming update carries a timestamp: some updates
+	// (test fixtures, mock CallService state changes) set only State/EntityID and
+	// leave LastUpdated at its zero value. Those must still apply, otherwise they
+	// would always look "older" than a previously synced, timestamped state.
 	current := entity.GetState()
-	if !current.LastUpdated.IsZero() && newState.LastUpdated.Before(current.LastUpdated) {
+	if !newState.LastUpdated.IsZero() && newState.LastUpdated.Before(current.LastUpdated) {
 		logger.Debug("Skipping stale state update", event.Event.EventData.EntityID)
 
 		return

--- a/connection_test.go
+++ b/connection_test.go
@@ -287,3 +287,60 @@ func TestNilStateLeavesStateUnchanged(t *testing.T) {
 	assert.Equal(t, "on", testEntity.GetState().State)
 	assert.Equal(t, int32(2), automationTriggered.Load())
 }
+
+// TestUntimestampedUpdateAppliesAfterTimestampedState verifies that an update
+// carrying no LastUpdated (zero time) still applies even after the entity holds
+// a timestamped state. Such updates are produced by tests and by the mock
+// CallService state changes; the staleness guard must only compare when the
+// incoming update actually carries a timestamp, otherwise every untimestamped
+// update would look "older" than a previously synced state and be dropped.
+func TestUntimestampedUpdateAppliesAfterTimestampedState(t *testing.T) {
+	t.Parallel()
+
+	conn, server, cleanup := testutil.NewClientServer(t)
+	defer cleanup()
+
+	var automationTriggered atomic.Int32
+
+	testEntity := hal.NewEntity("test.entity")
+	conn.RegisterEntities(testEntity)
+
+	conn.RegisterAutomations(
+		hal.NewAutomation().
+			WithName("test.automation").
+			WithEntities(testEntity).
+			WithAction(func(_ context.Context, _ hal.EntityInterface) {
+				automationTriggered.Add(1)
+			}),
+	)
+
+	t1 := time.Date(2026, 7, 17, 23, 0, 15, 0, time.UTC)
+
+	// Timestamped "on" state, as a sync from GetStates or a real event would set.
+	server.SendEvent(homeassistant.Event{
+		EventType: "state_changed",
+		EventData: homeassistant.EventData{
+			EntityID: "test.entity",
+			NewState: &homeassistant.State{State: "on", LastUpdated: t1},
+		},
+	})
+
+	// Untimestamped "off" update (zero LastUpdated) must still apply, not be
+	// treated as stale relative to the timestamped state above.
+	server.SendEvent(homeassistant.Event{
+		EventType: "state_changed",
+		EventData: homeassistant.EventData{
+			EntityID: "test.entity",
+			NewState: &homeassistant.State{State: "off"},
+		},
+	})
+
+	testutil.WaitFor(t, "verify untimestamped update applied", func() bool {
+		return automationTriggered.Load() == 2
+	}, func() {
+		spew.Dump(automationTriggered.Load(), testEntity.GetState())
+	})
+
+	assert.Equal(t, "off", testEntity.GetState().State)
+	assert.Equal(t, int32(2), automationTriggered.Load())
+}

--- a/hassws/client.go
+++ b/hassws/client.go
@@ -15,13 +15,19 @@ import (
 
 const readTimeoutSeconds = 3
 
-// eventChannelBufferSize bounds the per-listener response channel. The read loop
-// is the single sender, so a buffered channel preserves message order (FIFO)
-// while absorbing bursts that arrive while a handler is busy (e.g. blocked on a
-// synchronous CallService round-trip). It must be large enough that the read
-// loop rarely backpressures, which would otherwise stall CallService responses
-// that flow through the same read loop.
+// eventChannelBufferSize bounds the per-subscription response channel. The read
+// loop is the single sender, so a buffered channel preserves message order
+// (FIFO) while absorbing bursts. Subscription frames are drained off this
+// channel promptly by runOrderedHandler (which decouples handler execution from
+// draining), so this only needs to cover scheduling jitter, not a slow handler.
 const eventChannelBufferSize = 256
+
+// oneShotResponseBufferSize buffers the single expected response for one-shot
+// requests (CallService, GetStates). A buffer of one lets the read loop deliver
+// that response without blocking even if the caller has already timed out, and
+// the listener is removed as soon as the caller is done, so unlike a
+// subscription it does not retain a large buffer for the connection's lifetime.
+const oneShotResponseBufferSize = 1
 
 const (
 	// defaultPingInterval is how often a heartbeat ping is sent to Home
@@ -355,9 +361,10 @@ func (c *Client) listen(conn *websocket.Conn, done chan struct{}) {
 		}
 
 		// Deliver sequentially from this single read loop so events reach the
-		// handler in the order Home Assistant sent them. The channel is buffered
-		// (eventChannelBufferSize) so this rarely blocks; the recover() tolerates
-		// a send to a channel closed during shutdown/reconnect.
+		// handler in the order Home Assistant sent them. Listener channels are
+		// buffered and subscription frames are drained promptly by
+		// runOrderedHandler, so this rarely blocks; the recover() tolerates a
+		// send to a channel closed during shutdown/reconnect.
 		func(responseListenerCh chan []byte) {
 			defer func() {
 				if r := recover(); r != nil {
@@ -415,12 +422,15 @@ func (c *Client) send(msg any) error {
 	return c.writeMessage(c.conn, websocket.TextMessage, msgBytes)
 }
 
-// Add a listener channel for a response to a specific sent message.
-func (c *Client) addMessageResponseListener(msgID int) (ch chan []byte) {
+// Add a listener channel for a response to a specific sent message. bufferSize
+// bounds the channel: one-shot requests use a small buffer and remove the
+// listener once done, while long-lived subscriptions use a larger buffer to
+// absorb bursts.
+func (c *Client) addMessageResponseListener(msgID, bufferSize int) (ch chan []byte) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	ch = make(chan []byte, eventChannelBufferSize)
+	ch = make(chan []byte, bufferSize)
 	c.responses[msgID] = ch
 
 	return ch
@@ -433,36 +443,49 @@ func (c *Client) removeMessageResponseListener(msgID int) {
 	delete(c.responses, msgID)
 }
 
-// Send a message to the websocket and return a channel to listen for responses.
-func (c *Client) sendMessageStreamResponses(msgBytes []byte) (ch chan []byte, err error) {
+// registerAndSend assigns a unique ID to the message, registers a response
+// listener with the given buffer size, and sends it. It returns the message ID
+// and the listener channel. On send failure the listener is removed so it does
+// not linger in c.responses.
+func (c *Client) registerAndSend(msgBytes []byte, bufferSize int) (msgID int, ch chan []byte, err error) {
 	var msg jsonMessage
 	if err := json.Unmarshal(msgBytes, &msg); err != nil {
-		return nil, err
+		return 0, nil, err
 	}
 
-	msgID := c.nextMsgID()
+	msgID = c.nextMsgID()
 	msg["id"] = msgID
 
-	ch = c.addMessageResponseListener(msgID)
+	ch = c.addMessageResponseListener(msgID, bufferSize)
 
 	if err := c.send(msg); err != nil {
-		return nil, err
+		c.removeMessageResponseListener(msgID)
+
+		return 0, nil, err
 	}
 
-	return ch, nil
+	return msgID, ch, nil
 }
 
-// Send a message to the websocket and wait for a response.
+// Send a message to the websocket and return a channel to listen for a stream of
+// responses (e.g. a subscription). The listener lives for the connection's
+// lifetime, so it uses a larger buffer to absorb bursts.
+func (c *Client) sendMessageStreamResponses(msgBytes []byte) (ch chan []byte, err error) {
+	_, ch, err = c.registerAndSend(msgBytes, eventChannelBufferSize)
+
+	return ch, err
+}
+
+// Send a message to the websocket and wait for a single response.
 func (c *Client) sendMessageWaitResponse(msgBytes []byte) (response []byte, err error) {
-	responseChan, err := c.sendMessageStreamResponses(msgBytes)
+	msgID, responseChan, err := c.registerAndSend(msgBytes, oneShotResponseBufferSize)
 	if err != nil {
 		return nil, err
 	}
 
-	// Close channel after receiving first response
-	defer func() {
-		close(responseChan)
-	}()
+	// One-shot request: remove the listener once we are done so neither it nor
+	// its buffer lingers in c.responses for the lifetime of the connection.
+	defer c.removeMessageResponseListener(msgID)
 
 	return c.readMesssageFromChannel(responseChan)
 }
@@ -474,6 +497,90 @@ func (c *Client) readMesssageFromChannel(ch chan []byte) (response []byte, err e
 		return res, nil
 	case <-time.After(readTimeoutSeconds * time.Second):
 		return nil, ErrReadTimeout
+	}
+}
+
+// frameQueue is an unbounded, order-preserving FIFO of raw websocket frames
+// with a single producer and a single consumer. It lets a subscription's frames
+// be moved off the shared response channel immediately, without waiting for a
+// (potentially slow) handler to finish, so the read loop is never blocked.
+type frameQueue struct {
+	mutex  sync.Mutex
+	cond   *sync.Cond
+	buf    [][]byte
+	closed bool
+}
+
+func newFrameQueue() *frameQueue {
+	q := &frameQueue{}
+	q.cond = sync.NewCond(&q.mutex)
+
+	return q
+}
+
+// push appends a frame. It never blocks the caller (the read loop).
+func (q *frameQueue) push(b []byte) {
+	q.mutex.Lock()
+	q.buf = append(q.buf, b)
+	q.mutex.Unlock()
+
+	q.cond.Signal()
+}
+
+// close marks the queue closed. pop returns the remaining frames and then
+// reports the queue as drained.
+func (q *frameQueue) close() {
+	q.mutex.Lock()
+	q.closed = true
+	q.mutex.Unlock()
+
+	q.cond.Broadcast()
+}
+
+// pop blocks until a frame is available and returns it, or returns ok=false once
+// the queue is closed and fully drained.
+func (q *frameQueue) pop() (b []byte, ok bool) {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+
+	for len(q.buf) == 0 && !q.closed {
+		q.cond.Wait()
+	}
+
+	if len(q.buf) == 0 {
+		return nil, false
+	}
+
+	b = q.buf[0]
+	q.buf = q.buf[1:]
+
+	return b, true
+}
+
+// runOrderedHandler consumes raw frames from ch and invokes handle for each, in
+// receipt order. It decouples draining ch from running handle: frames are moved
+// off ch into an unbounded queue as fast as they arrive, while handle runs one
+// at a time from that queue. This ensures a handler that blocks (e.g. one making
+// a synchronous CallService whose result is delivered by the same read loop)
+// can never fill ch and stall the shared read loop.
+func runOrderedHandler(ch chan []byte, handle func([]byte)) {
+	queue := newFrameQueue()
+
+	go func() {
+		for b := range ch {
+			queue.push(b)
+		}
+
+		queue.close()
+	}()
+
+	for {
+		b, ok := queue.pop()
+		if !ok {
+			return
+		}
+
+		handle(b)
 	}
 }
 
@@ -516,19 +623,18 @@ func (c *Client) SubscribeEvents(eventType string, handler func(EventMessage)) e
 		return fmt.Errorf("%w: %s", ErrUnexpectedResponse, resBytes)
 	}
 
-	// Create Goroutine to event messages and dispatch to handler
-	go func(ch chan []byte) {
-		for b := range ch {
-			var msg EventMessage
-			if err := json.Unmarshal(b, &msg); err != nil {
-				logger.Error("Error unmarshalling event message", "", "error", err)
+	// Dispatch events to the handler in order. runOrderedHandler drains
+	// responseChan promptly so a slow handler cannot back up the shared read loop.
+	go runOrderedHandler(responseChan, func(b []byte) {
+		var msg EventMessage
+		if err := json.Unmarshal(b, &msg); err != nil {
+			logger.Error("Error unmarshalling event message", "", "error", err)
 
-				continue
-			}
-
-			handler(msg)
+			return
 		}
-	}(responseChan)
+
+		handler(msg)
+	})
 
 	logger.Info("Listening for state changes", "")
 
@@ -575,11 +681,9 @@ func (c *Client) SubscribeEventsRaw(eventType string, handler func([]byte)) erro
 		return fmt.Errorf("%w: %s", ErrUnexpectedResponse, resBytes)
 	}
 
-	go func(ch chan []byte) {
-		for b := range ch {
-			handler(b)
-		}
-	}(responseChan)
+	// Dispatch raw frames to the handler in order. runOrderedHandler drains
+	// responseChan promptly so a slow handler cannot back up the shared read loop.
+	go runOrderedHandler(responseChan, handler)
 
 	return nil
 }

--- a/hassws/client_internal_test.go
+++ b/hassws/client_internal_test.go
@@ -1,6 +1,7 @@
 package hassws
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -56,5 +57,113 @@ func TestNewClientReadTimeoutDefaults(t *testing.T) {
 			assert.Equal(t, tc.wantPingInterval, c.cfg.PingInterval)
 			assert.Equal(t, tc.wantReadTimeout, c.cfg.ReadTimeout)
 		})
+	}
+}
+
+// TestFrameQueueOrderAndUnbounded verifies that frameQueue preserves FIFO order,
+// accepts more items than any fixed buffer without a consumer (unbounded), and
+// drains fully before reporting closed.
+func TestFrameQueueOrderAndUnbounded(t *testing.T) {
+	t.Parallel()
+
+	q := newFrameQueue()
+
+	const n = 1000
+
+	// Push far more than any fixed buffer with no consumer running; push must
+	// never block.
+	for i := range n {
+		q.push([]byte{byte(i), byte(i >> 8)})
+	}
+
+	q.close()
+
+	// Everything pushed comes back out in order.
+	for i := range n {
+		b, ok := q.pop()
+		assert.Equal(t, true, ok)
+		assert.Equal(t, byte(i), b[0])
+		assert.Equal(t, byte(i>>8), b[1])
+	}
+
+	// Once drained and closed, pop reports no more frames.
+	_, ok := q.pop()
+	assert.Equal(t, false, ok)
+}
+
+// TestRunOrderedHandlerDoesNotBlockProducerOnSlowHandler verifies the property
+// that keeps the shared read loop alive: a slow (parked) handler must not stop
+// frames from being drained off the input channel. If handler execution were
+// coupled to draining (as it is when a single goroutine both receives and
+// invokes the handler), a handler blocked in a synchronous CallService would
+// stall the producer - here the read loop - and deadlock it.
+func TestRunOrderedHandlerDoesNotBlockProducerOnSlowHandler(t *testing.T) {
+	t.Parallel()
+
+	// Unbuffered: a send only succeeds if runOrderedHandler's drainer receives.
+	ch := make(chan []byte)
+	release := make(chan struct{})
+
+	var (
+		mu        sync.Mutex
+		processed []byte
+		parked    sync.Once
+	)
+
+	go runOrderedHandler(ch, func(b []byte) {
+		// Park on the very first frame, simulating a handler blocked in a
+		// synchronous CallService.
+		firstFrame := false
+		parked.Do(func() { firstFrame = true })
+
+		if firstFrame {
+			<-release
+		}
+
+		mu.Lock()
+		processed = append(processed, b[0])
+		mu.Unlock()
+	})
+
+	const n = 1000
+
+	// Send while the handler is parked. Each send must complete promptly because
+	// the drainer keeps moving frames off ch even though the handler is blocked.
+	for i := range n {
+		select {
+		case ch <- []byte{byte(i)}:
+		case <-time.After(2 * time.Second):
+			close(release)
+			t.Fatalf("producer blocked sending frame %d: draining is coupled to the slow handler", i)
+		}
+	}
+
+	// Unblock the handler and let the queue drain.
+	close(release)
+	close(ch)
+
+	deadline := time.After(2 * time.Second)
+	for {
+		mu.Lock()
+		done := len(processed) == n
+		mu.Unlock()
+
+		if done {
+			break
+		}
+
+		select {
+		case <-deadline:
+			t.Fatal("handler did not process all frames")
+		case <-time.After(time.Millisecond):
+		}
+	}
+
+	// Frames were processed in the order they were sent.
+	mu.Lock()
+	defer mu.Unlock()
+
+	for i := range n {
+		assert.Equal(t, byte(i), processed[i])
 	}
 }


### PR DESCRIPTION
Addresses the three Codex review comments on #14. Targets the `fix/out-of-order-state-updates` branch so it stacks onto that PR.

## Changes

**1. Untimestamped updates apply after a timestamped sync** (`connection.go`)
The staleness guard compared the currently held timestamp instead of the incoming one. After a timestamped sync (from `GetStates` or a real event), any `state_changed` payload without a `LastUpdated` — which the tests and the mock `CallService` state updates produce — looked "older" than the current state (zero time is before everything) and was dropped, so it never changed state or fired automations. The guard now only compares when the **incoming** update carries a timestamp.

**2. Read loop can no longer be blocked by a busy subscription** (`hassws/client.go`)
A subscription handler that makes a synchronous `CallService` waits on a result delivered by the same read loop. With a plain buffered channel, enough queued subscription frames would fill the buffer, block the read loop's send, and deadlock the pending `CallService` (it would time out instead of completing). Subscription frames are now drained off the response channel immediately into an unbounded, order-preserving FIFO (`runOrderedHandler` / `frameQueue`), decoupling handler execution from draining while preserving per-subscription order.

**3. One-shot requests no longer retain a large buffer** (`hassws/client.go`)
`CallService` and `GetStates` listeners were given the 256-entry subscription buffer and were not removed until reconnect/shutdown, so every service call retained a large channel for the connection's lifetime. One-shot requests now use a buffer of one and their listener is removed as soon as the response arrives.

## Tests
- `TestUntimestampedUpdateAppliesAfterTimestampedState` — untimestamped update applies (and fires automations) after a timestamped state.
- `TestFrameQueueOrderAndUnbounded` — FIFO order preserved, accepts more items than any fixed buffer with no consumer, drains fully before reporting closed.
- `TestRunOrderedHandlerDoesNotBlockProducerOnSlowHandler` — a handler parked mid-frame never blocks the producer feeding the channel (verified to fail if draining is recoupled to the handler).

All existing tests continue to pass. (A pre-existing data race in `automations/TestHumanOverride` is unrelated to these changes and untouched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2JrD3FnPGqsQgnvXFNi2j)_